### PR TITLE
Remove recursively calling goto when nextState not found and return false when state not found

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,8 +83,6 @@ export default class Machine<S> extends erx.Bus<StateName> {
         });
       } else if (nextState.animations) {
         nextState.animations(this, getState)
-      } if (typeof next === "string") {
-        this.goTo(next, getState);
       }
     };
 
@@ -120,7 +118,7 @@ export default class Machine<S> extends erx.Bus<StateName> {
     }
 
     if (!nextState) {
-      return true
+      return false
     }
 
     return this.goTo(nextState, getState);


### PR DESCRIPTION
I was writing the readme and i couldn't find a reason to include this part? Why is goto calling itself if there are no animations, is it retrying to run the function?

Also think it makes sense to return false rather than true if nextState doesn't exist